### PR TITLE
Python versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ That includes:
 
 
 ## Installation:
-- change the first line of `setup.py` to point to the directory of your installation of python 2.*
+
 - run `python setup.py install --user`
 
 **Note**: This will only install `monerorpc`. If you also want to install `jsonrpc` to preserve

--- a/setup.py
+++ b/setup.py
@@ -2,19 +2,26 @@
 
 from setuptools import setup
 
-setup(name='python-monerorpc',
-      version='0.5.3',
-      description='Enhanced version of python-jsonrpc for Monero (monerod, monero-wallet-rpc).',
-      long_description=open('README.md').read(),
-      long_description_content_type='text/markdown',
-      author='Norman Moeschter-Schenck',
-      author_email='<norman.moeschter@gmail.com>',
-      maintainer='Norman Moeschter-Schenck',
-      maintainer_email='<norman.moeschter@gmail.com>',
-      url='https://www.github.com/monero-ecosystem/python-monerorpc',
-      download_url='https://github.com/monero-ecosystem/python-monerorpc/archive/0.5.3.tar.gz',
-      packages=['monerorpc'],
-      install_requires=[
-          'requests',
-      ],
-      classifiers=['License :: OSI Approved :: MIT License', 'Operating System :: OS Independent'])
+setup(
+    name='python-monerorpc',
+    version='0.5.3',
+    description='Enhanced version of python-jsonrpc for Monero (monerod, monero-wallet-rpc).',
+    long_description=open('README.md').read(),
+    long_description_content_type='text/markdown',
+    author='Norman Moeschter-Schenck',
+    author_email='<norman.moeschter@gmail.com>',
+    maintainer='Norman Moeschter-Schenck',
+    maintainer_email='<norman.moeschter@gmail.com>',
+    url='https://www.github.com/monero-ecosystem/python-monerorpc',
+    download_url='https://github.com/monero-ecosystem/python-monerorpc/archive/0.5.3.tar.gz',
+    packages=['monerorpc'],
+    install_requires=[
+        'requests',
+    ],
+    classifiers=[
+        'License :: OSI Approved :: MIT License',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 2.7'
+    ]
+)


### PR DESCRIPTION
This package seems to work fine under python 2 and python 3, so I added it to the `classifiers` on `setup.py`, since according to the [packaging documentation](https://packaging.python.org/tutorials/packaging-projects/#creating-setup-py):

> You should always include at least which version(s) of Python your package works on, which license your package is available under, and which operating systems your package will work on. 

Also removed the indication to edit the `setup.py` from the readme, since it is not required for the given command. It only would be required if the user wants to execute the file like this: `./setup.py install --user`.