### PR TITLE
Tests on all supported python versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build/
 .coverage
 .mypy_cache
 .pytest_cache
+.tox

--- a/README.md
+++ b/README.md
@@ -186,22 +186,23 @@ Produces output on stderr like:
 
 Possible errors and error codes:
 
-* `no code`
+- `no code`
   - Returns the `error` contained in the RPC response.
-* `-341`
+- `-341`
   - `could not establish a connection, original error: {}`
   - including the original exception message
-* `-342`
+- `-342`
   - `missing HTTP response from server`
-* `-343`
+- `-343`
   - `missing JSON-RPC result`
-* `-344`
+- `-344`
   - `received HTTP status code {}`
   - including HTTP status code other than `200`
 
 ## Testing:
 
 Install the test requirements:
+
 ```bash
     virtualenv -q venv
     . venv/bin/activate
@@ -209,13 +210,28 @@ Install the test requirements:
 ```
 
 Run unit tests using `pytest`:
+
 ```bash
     # virtualenv activated (see above)
     pytest tests.py
 ```
 
+Run unit tests on all supported python versions:
+
+```bash
+    tox -q
+```
+
+Run unit tests on a subset of the supported python versions:
+
+```bash
+    tox -q -e py27,py34
+```
+
+**Note:** The chosen python versions have to be installed on your system.
+
 ## Authors
 
-* **Norman Moeschter-Schenck** - *Initial work* - [normoes](https://github.com/normoes)
+- **Norman Moeschter-Schenck** - _Initial work_ - [normoes](https://github.com/normoes)
 
 See also the list of [contributors](contributors.md) who participated in this project.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-pytest
-pytest-cov
-requests
-responses
+pytest==4.1.1
+pytest-cov==2.6.1
+requests==2.21.0
+responses==0.10.5
+tox==3.7.0

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,10 @@ setup(
     classifiers=[
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 2.7",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = py27,py34,py35,py36,py37
+
+
+[testenv]
+deps = -r requirements.txt
+commands =
+    pytest tests.py


### PR DESCRIPTION
Since this package runs on both python 2 and 3, this pull request adds `tox` so we can easily run the test suite on all supported versions.

Additionally the versions of all development/testing dependencies were pinned, to reduce variations on the testing environment.